### PR TITLE
Improve song detection

### DIFF
--- a/VideoCapture/AnnotableViewer.swift
+++ b/VideoCapture/AnnotableViewer.swift
@@ -47,19 +47,25 @@ class AnnotableViewer: NSView {
     // drawn annotations
     internal var annotations: [Annotation] = [] {
         didSet {
-            self.needsDisplay = true
+            flagForDisplay()
         }
     }
     
     // current annotation
     private var annotationInProgress: Annotation? {
         didSet {
-            self.needsDisplay = true
+            // both nil? nothing to do
+            if oldValue == nil && annotationInProgress == nil { return }
+            
+            flagForDisplay()
         }
     }
     
     var enabled: Bool = true {
         didSet {
+            // actually changed?
+            guard oldValue != enabled else { return }
+            
             locationDown = nil
             annotationInProgress = nil
             segmentedSelector?.enabled = enabled
@@ -95,6 +101,17 @@ class AnnotableViewer: NSView {
             if let v = view {
                 v.frame = frame
                 addSubview(v)
+            }
+        }
+    }
+    
+    func flagForDisplay() {
+        if NSThread.isMainThread() {
+            needsDisplay = true
+        }
+        else {
+            dispatch_async(dispatch_get_main_queue()) {
+                self.needsDisplay = true
             }
         }
     }

--- a/VideoCapture/AppDelegate.swift
+++ b/VideoCapture/AppDelegate.swift
@@ -8,7 +8,31 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+    // get instance
+    class var instance: AppDelegate {
+        get {
+            return NSApp.delegate as! AppDelegate
+        }
+    }
+    
+    private var usedDevices = [String]()
     private let crashReporter = PLCrashReporter()
+    
+    // MANAGE LIST OF IN USE DEVICES
+
+    func startUsingDevice(deviceID: String) {
+        usedDevices.append(deviceID)
+    }
+    
+    func stopUsingDevice(deviceID: String) {
+        usedDevices = usedDevices.filter { $0 != deviceID }
+    }
+    
+    func isUsingDevice(deviceID: String) -> Bool {
+        return usedDevices.contains(deviceID)
+    }
+    
+    // CRASH REPORTING
     
     private func processCrashReport(crashReport: PLCrashReport) {
         // get string

--- a/VideoCapture/Common.swift
+++ b/VideoCapture/Common.swift
@@ -17,3 +17,9 @@ func distance(a: CGPoint, _ b: CGPoint) -> CGFloat {
     let x = a.x - b.x, y = a.y - b.y
     return sqrt((x * x) + (y * y))
 }
+
+extension Int {
+    func isPowerOfTwo() -> Bool {
+        return (self != 0) && (self & (self - 1)) == 0
+    }
+}

--- a/VideoCapture/Info.plist
+++ b/VideoCapture/Info.plist
@@ -40,11 +40,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>17</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.education</string>
 	<key>LSMinimumSystemVersion</key>

--- a/VideoCapture/Info.plist
+++ b/VideoCapture/Info.plist
@@ -40,11 +40,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>15</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.education</string>
 	<key>LSMinimumSystemVersion</key>

--- a/VideoCapture/Preferences.swift
+++ b/VideoCapture/Preferences.swift
@@ -20,7 +20,7 @@ struct Preferences {
     let pinAnalogLED = 13
     
     // frames after song to store
-    let secondsAfterSong = 3.0
+    let secondsAfterSong = 1.5
     
     // output format
     let videoFormat = PreferenceVideoFormat.H264

--- a/VideoCapture/SongDetection/DebounceBoolean.swift
+++ b/VideoCapture/SongDetection/DebounceBoolean.swift
@@ -22,6 +22,8 @@ class DebounceBoolean
     }
     
     init(checks: Int, initial: Bool = false) {
+        DLog("Debouce(checks=\(checks))")
+        
         self.checks = checks
         last = initial
     }

--- a/VideoCapture/SongDetection/ExponentialMovingAverage.swift
+++ b/VideoCapture/SongDetection/ExponentialMovingAverage.swift
@@ -20,9 +20,18 @@ class ExponentialMovingAverage
         }
     }
     
-    init(tau: Double, initial: Double = 0.0) {
-        k = exp(-2 * M_PI / tau)
+    init(tau: Double, samplingRate: Double, initial: Double = 0.0) {
+        k = exp(-1 / (samplingRate * tau))
         last = initial
+        
+        DLog("ExponentialMovingAverage(tau=\(tau), k=\(k))")
+    }
+    
+    init(tau: Double, timePerSample: Double, initial: Double = 0.0) {
+        k = exp(-timePerSample / tau)
+        last = initial
+        
+        DLog("ExponentialMovingAverage(tau=\(tau), k=\(k))")
     }
     
     func ingest(val: Double) -> Double {

--- a/VideoCapture/SongDetection/SchmittForCapture.swift
+++ b/VideoCapture/SongDetection/SchmittForCapture.swift
@@ -95,7 +95,7 @@ class SchmittForCapture
         
         if isTrigger {
             state = .High
-            count = framesLow
+            count = framesHigh
             return true
         }
         

--- a/VideoCapture/SongDetection/SongDetector.swift
+++ b/VideoCapture/SongDetection/SongDetector.swift
@@ -39,7 +39,7 @@ class SongDetector: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate
     }
     
     var thresholdSongNonsongRatio = 1.4
-    var thresholdSongBackgroundRatio = 1.4
+    var thresholdSongBackgroundRatio = 25.0
     
     var iterationsAfterSong = 0 // measured in terms of non-overlapping STFT segments
     var secondsAfterSong: Double {

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -82,6 +82,14 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
             }
         }
         didSet {
+            // manage list of used devices
+            if let ov = oldValue {
+                AppDelegate.instance.stopUsingDevice(ov.device.uniqueID)
+            }
+            if let nv = avInputVideo {
+                AppDelegate.instance.startUsingDevice(nv.device.uniqueID)
+            }
+            
             // update interface options
             refreshInterface()
             
@@ -93,6 +101,15 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
     }
     var avInputAudio: AVCaptureDeviceInput? {
         didSet {
+            // manage list of used devices
+            if let ov = oldValue {
+                AppDelegate.instance.stopUsingDevice(ov.device.uniqueID)
+            }
+            if let nv = avInputAudio {
+                AppDelegate.instance.startUsingDevice(nv.device.uniqueID)
+            }
+            
+            // update interface options
             refreshInterface()
             
             // changed state
@@ -160,6 +177,14 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
     // serial communications
     var ioArduino: ArduinoIO? {
         didSet {
+            // manage list of used devices
+            if let ov = oldValue, let path = ov.serial?.path {
+                AppDelegate.instance.stopUsingDevice(path)
+            }
+            if let nv = ioArduino, let path = nv.serial?.path {
+                AppDelegate.instance.startUsingDevice(path)
+            }
+            
             oldValue?.delegate = nil
             ioArduino?.delegate = self
             
@@ -1366,6 +1391,26 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
         if let selected = sender.selectedItem, let deviceUniqueID = deviceUniqueIDs[selected.tag] {
             DLog("Device ID: \(deviceUniqueID)")
             
+            // is device used?
+            if AppDelegate.instance.isUsingDevice(deviceUniqueID) && avInputVideo?.device.uniqueID != deviceUniqueID {
+                // show alert
+                let alert = NSAlert()
+                alert.messageText = "Device already in use"
+                alert.informativeText = "The device you selected is already in use in another window. Running multiple captures from the same device may cause problems."
+                alert.addButtonWithTitle("Ok")
+                if let win = NSApp.keyWindow {
+                    alert.beginSheetModalForWindow(win, completionHandler:nil)
+                }
+                else {
+                    alert.runModal()
+                }
+                
+                // reset selector
+                sender.selectItemAtIndex(0)
+                
+                return
+            }
+            
             // get existing device
             if nil != avInputVideo {
                 // should be defined
@@ -1432,6 +1477,26 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
         if let selected = sender.selectedItem, let deviceUniqueID = deviceUniqueIDs[selected.tag] {
             DLog("Device ID: \(deviceUniqueID)")
             
+            // is device used?
+            if AppDelegate.instance.isUsingDevice(deviceUniqueID) && avInputAudio?.device.uniqueID != deviceUniqueID {
+                // show alert
+                let alert = NSAlert()
+                alert.messageText = "Device already in use"
+                alert.informativeText = "The device you selected is already in use in another window. Running multiple captures from the same device may cause problems."
+                alert.addButtonWithTitle("Ok")
+                if let win = NSApp.keyWindow {
+                    alert.beginSheetModalForWindow(win, completionHandler:nil)
+                }
+                else {
+                    alert.runModal()
+                }
+                
+                // reset selector
+                sender.selectItemAtIndex(0)
+                
+                return
+            }
+            
             // get existing device
             if nil != avInputAudio {
                 // should be defined
@@ -1479,6 +1544,26 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
     @IBAction func selectSerialPort(sender: NSPopUpButton!) {
         if let selected = sender.selectedItem, let devicePath = deviceUniqueIDs[selected.tag] {
             DLog("Device Path: \(devicePath)")
+            
+            // is device used?
+            if AppDelegate.instance.isUsingDevice(devicePath) && ioArduino?.serial?.path != devicePath {
+                // show alert
+                let alert = NSAlert()
+                alert.messageText = "Device already in use"
+                alert.informativeText = "The device you selected is already in use in another window. Running multiple captures from the same device may cause problems."
+                alert.addButtonWithTitle("Ok")
+                if let win = NSApp.keyWindow {
+                    alert.beginSheetModalForWindow(win, completionHandler:nil)
+                }
+                else {
+                    alert.runModal()
+                }
+                
+                // reset selector
+                sender.selectItemAtIndex(0)
+                
+                return
+            }
             
             // get existing device
             if nil != ioArduino {

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -34,7 +34,7 @@ enum VideoCaptureMode {
     }
 }
 
-class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AVCaptureVideoDataOutputSampleBufferDelegate, NSTableViewDelegate {
+class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
     // document mode
     var mode = VideoCaptureMode.Configure {
         didSet {

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -1761,7 +1761,6 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
                 alert.runModal()
             }
 
-            
             return
         }
         
@@ -2249,6 +2248,13 @@ extension ViewController: SongDetectorDelegate {
         
         // has triggered? start capturing
         if shouldCapture {
+            // get output directory
+            guard let dir = dirOut else {
+                DLog("Output directory has gone away.")
+                stopMonitoring()
+                return
+            }
+            
             // turn on LED and camera
             do {
                 try ioArduino?.writeTo(appPreferences.pinDigitalCamera, digitalValue: true)
@@ -2258,12 +2264,6 @@ extension ViewController: SongDetectorDelegate {
             }
             catch {
                 
-            }
-            
-            guard let dir = dirOut else {
-                DLog("Output directory has gone away.")
-                stopMonitoring()
-                return
             }
             
             // format

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -662,6 +662,12 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
             }
         }
         
+        // turn off LED before hand (avoid bleaching)
+        do {
+            try ioArduino?.writeTo(appPreferences.pinAnalogLED, analogValue: UInt8(0))
+        }
+        catch { }
+        
         // show
         if let win = NSApp.keyWindow {
             panel.beginSheetModalForWindow(win, completionHandler: cb)

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -441,7 +441,13 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
             for d in devices_video {
                 let dev: AVCaptureDevice = d as! AVCaptureDevice
                 let item = NSMenuItem()
-                item.title = dev.localizedName
+                if dev.inUseByAnotherApplication {
+                    item.title = dev.localizedName + " (in use)"
+                    item.enabled = false
+                }
+                else {
+                    item.title = dev.localizedName
+                }
                 item.tag = newDeviceIndex
                 list.menu?.addItem(item)
                 newDeviceUniqueIDs[newDeviceIndex] = dev.uniqueID
@@ -475,7 +481,24 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
             for d in devices_audio {
                 let dev: AVCaptureDevice = d as! AVCaptureDevice
                 let item = NSMenuItem()
-                item.title = dev.localizedName
+                if dev.inUseByAnotherApplication {
+                    item.title = "\(dev.localizedName) (in use)"
+                    item.enabled = false
+                }
+                else if dev.localizedName == "USB2.0 MIC" {
+                    // try to give it a nicer name
+                    let parts = dev.uniqueID.characters.split { $0 == ":" }.map(String.init)
+                    let c = parts.count
+                    if c > 1 {
+                        item.title = "USB MIC (\(parts[c-2]) \(parts[c-1]))"
+                    }
+                    else {
+                        item.title = "\(dev.localizedName)"
+                    }
+                }
+                else {
+                    item.title = dev.localizedName
+                }
                 item.tag = newDeviceIndex
                 list.menu?.addItem(item)
                 newDeviceUniqueIDs[newDeviceIndex] = dev.uniqueID

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -1060,7 +1060,7 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         headers += "Date,\(formatter.stringFromDate(date))\n"
         
-        headers += "Name"
+        headers += "Time"
         if nil != songDetector {
             headers += ",SongNonsongRatio,SongBackgroundRatio,Detected"
         }
@@ -1663,7 +1663,7 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
     }
     
     func captureOutput(captureOutput: AVCaptureFileOutput!, didFinishRecordingToOutputFileAtURL outputFileURL: NSURL!, fromConnections connections: [AnyObject]!, error: NSError?) {
-        var success = true;
+        var success = true
         
         if let e = error where noErr != OSStatus(e.code) {
             if let val = e.userInfo[AVErrorRecordingSuccessfullyFinishedKey] {

--- a/VideoCapture/ViewController.swift
+++ b/VideoCapture/ViewController.swift
@@ -795,7 +795,7 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
         // create song detector
         let audioDescription = CMAudioFormatDescriptionGetStreamBasicDescription(audioInput.device.activeFormat.formatDescription)
         songDetector = SongDetector(samplingRate: audioDescription[0].mSampleRate)
-        songDetector?.msAfterSong = appPreferences.secondsAfterSong * 1000.0
+        songDetector?.secondsAfterSong = appPreferences.secondsAfterSong
         songDetector?.delegate = self
         
         // create serial dispatch queue
@@ -1062,7 +1062,7 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
         
         headers += "Name"
         if nil != songDetector {
-            headers += ",Ratio,SongDb,Detected"
+            headers += ",SongNonsongRatio,SongBackgroundRatio,Detected"
         }
         for annot in annotView.annotations {
             headers += ",\(annot.name)"
@@ -1928,7 +1928,7 @@ class ViewController: NSViewController, AVCaptureFileOutputRecordingDelegate, AV
             var sampleString = "\(timestampAsSeconds)"
             sampleString.reserveCapacity(64)
             if let sd = songDetector {
-                sampleString += ",\(sd.lastRatio),\(sd.lastDecibelSong)"
+                sampleString += ",\(sd.lastSongNonsongRatio),\(sd.lastSongBackgroundRatio),\(sd.lastDetected ? 1 : 0)"
             }
             for val in extractValues {
                 sampleString += ",\(val)"


### PR DESCRIPTION
This pull requests incorporates a number of improvements into the song detector to make it both more robust and consistent across microphones and recording environments, as well as other general improvements to remove minor bugs and issues.

The song detector now uses an updated FFT library and replaces the absolute decibel threshold with a second ratio threshold, the ratio of song to background noise. Song is calculated as the short-term moving average of spectral power in the song range, while background is calculated as the long-term moving average of the spectral power in the song range. This provides an environmentally adapted threshold and can eliminate idiosyncrasies of microphones. 

The updated FFT library reduces computational load, introduces better debounce detection and better exponential moving average calculation.

Finally, the song detector has been modified to double the recording time if it sees two leading edges from the detector, allowing for a shorter capture time by default.

Other minor improvements include:
- Turning off the LED when beginning monitoring before selecting an output directory.
- Providing more descriptive names for audio devices.
- Preventing duplicate captures from the same device.
- Bugfixes related to drawing actions on background threads.
